### PR TITLE
Change from ListResource to FindPackageByIdResource

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,6 @@
 mode: "ContinuousDeployment"
 branches:
   master:
+    regex: ^main
     tag: preview
     increment: Minor

--- a/Solutions/Endjin.SemVer.DotNetApi/Endjin/SemVer/DotNetApi/PackageComparison/INuGetPublishedLibraryMinorVersions.cs
+++ b/Solutions/Endjin.SemVer.DotNetApi/Endjin/SemVer/DotNetApi/PackageComparison/INuGetPublishedLibraryMinorVersions.cs
@@ -4,7 +4,7 @@
 
 namespace Endjin.SemVer.DotNetApi.PackageComparison
 {
-    using NuGet.Packaging.Core;
+    using NuGet.Versioning;
 
     /// <summary>
     /// Information about the versions of a library already published matching a particular
@@ -16,7 +16,7 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
         /// Gets the identity of the published package with the highest minor version number of
         /// all versions that share <see cref="MajorVersion"/>.
         /// </summary>
-        PackageIdentity LatestPublishedVersionWithSameMajor { get; }
+        NuGetVersion LatestPublishedVersionWithSameMajor { get; }
 
         /// <summary>
         /// Gets the latest minor version number with which a package sharing <see cref="MajorVersion"/>
@@ -35,9 +35,9 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
         int MajorVersion { get; }
 
         /// <summary>
-        /// Returns the patch number of highest published version with a major version number
-        /// matching <see cref="MajorVersion"/>, and with
-        /// the specified minor version number, if any such version has been published.
+        /// Returns highest published version with a major version number matching
+        /// <see cref="MajorVersion"/>, and with the specified minor version number, if any such
+        /// version has been published.
         /// </summary>
         /// <param name="minorVersion">
         /// The minor version required.
@@ -50,6 +50,6 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
         /// True if at least one version with a matching major.minor version number has been published.
         /// False if no version with the relevant major.minor version number has been published.
         /// </returns>
-        bool TryGetLatestVersionWithMinorVersion(int minorVersion, out PackageIdentity lastestPublishedPatchVersion);
+        bool TryGetLatestVersionWithMinorVersion(int minorVersion, out NuGetVersion lastestPublishedPatchVersion);
     }
 }

--- a/Solutions/Endjin.SemVer.DotNetApi/Endjin/SemVer/DotNetApi/PackageComparison/INuGetPublishedLibraryVersions.cs
+++ b/Solutions/Endjin.SemVer.DotNetApi/Endjin/SemVer/DotNetApi/PackageComparison/INuGetPublishedLibraryVersions.cs
@@ -4,7 +4,7 @@
 
 namespace Endjin.SemVer.DotNetApi.PackageComparison
 {
-    using NuGet.Packaging.Core;
+    using NuGet.Versioning;
 
     /// <summary>
     /// Provides information about the various versions of a library published in a NuGet feed.
@@ -12,9 +12,9 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
     public interface INuGetPublishedLibraryVersions
     {
         /// <summary>
-        /// Gets the identity of the latest published version of this library.
+        /// Gets the latest published version of this library.
         /// </summary>
-        PackageIdentity LatestPublishedVersion { get; }
+        NuGetVersion LatestPublishedVersion { get; }
 
         /// <summary>
         /// Gets the highest major version number of all versions already published.
@@ -45,7 +45,7 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
         /// <see cref="INuGetPublishedLibraryMinorVersions.LatestPublishedVersionWithSameMajor"/>
         /// of 2 (because the latest published version with a major version of 1 is v1.2.20). If
         /// you call the resulting object's
-        /// <see cref="INuGetPublishedLibraryMinorVersions.TryGetLatestVersionWithMinorVersion(int, out PackageIdentity)"/>
+        /// <see cref="INuGetPublishedLibraryMinorVersions.TryGetLatestVersionWithMinorVersion(int, out NuGetVersion)"/>
         /// method with a <c>minorVersion</c> of 0, it will return a
         /// <c>lastestPublishedPatchVersion</c> of 15 (because the latest published version with a
         /// major.minor version of 1.0 is v1.0.15). If you pass a <c>minorVersion</c> of 1, it will

--- a/Solutions/Endjin.SemVer.DotNetApi/Endjin/SemVer/DotNetApi/PackageComparison/PublishedLibrary.cs
+++ b/Solutions/Endjin.SemVer.DotNetApi/Endjin/SemVer/DotNetApi/PackageComparison/PublishedLibrary.cs
@@ -6,7 +6,7 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
 {
     using System.Collections.Generic;
     using System.Linq;
-    using NuGet.Packaging.Core;
+    using NuGet.Versioning;
 
     /// <summary>
     /// Provides information about the various versions of a library published in a NuGet feed.
@@ -21,10 +21,10 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
         /// <param name="publishedVersions">
         /// The versions of this library that have been published.
         /// </param>
-        public PublishedLibrary(IEnumerable<PackageIdentity> publishedVersions)
+        public PublishedLibrary(IEnumerable<NuGetVersion> publishedVersions)
         {
             this.latestMinorsByMajor = publishedVersions
-                .GroupBy(v => v.Version.Major)
+                .GroupBy(v => v.Major)
                 .ToDictionary(
                     g => g.Key,
                     g => (INuGetPublishedLibraryMinorVersions)new MinorVersions(g));
@@ -32,55 +32,13 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
             this.LatestPublishedVersion = publishedVersions.Max();
         }
 
-        /// <summary>
-        /// Gets the identity of the latest published version of this library.
-        /// </summary>
-        public PackageIdentity LatestPublishedVersion { get; }
+        /// <inheritdoc/>
+        public NuGetVersion LatestPublishedVersion { get; }
 
-        /// <summary>
-        /// Gets the highest major version number of all versions already published.
-        /// </summary>
+        /// <inheritdoc/>
         public int LatestPublishedMajorVersion => this.LatestPublishedVersion.Version.Major;
 
-        /// <summary>
-        /// Discovers, for a given major version, each minor version that has been published, and
-        /// returns information about the latest published version of each such minor version.
-        /// </summary>
-        /// <param name="majorVersion">The major version number of interest.</param>
-        /// <param name="latestMatchingMinorVersion">
-        /// Information about the latest published version for each distinct minor version for
-        /// which at least one version has been published.
-        /// </param>
-        /// <returns>
-        /// True if at least one version with the specified major version has been published, false
-        /// if none found.
-        /// </returns>
-        /// <remarks>
-        /// <para>
-        /// Suppose the following versions have been published: v1.0.0, v1.0.13, v1.0.15, v1.1.2,
-        /// v1.2.10, v1.2.20, v2.0.14, v2.0.25, v2.2.12, v2.3.98, v2.3.104.
-        /// </para>
-        /// <para>
-        /// Calling this method with a <c>majorVersion</c> of 1 will return a <see cref="MinorVersions"/>
-        /// reporting a <see cref="MinorVersions.LatestPublishedVersionWithSameMajor"/> of 2 (because the latest
-        /// published version with a major version of 1 is v1.2.20). If you call the resulting object's
-        /// <see cref="MinorVersions.TryGetLatestVersionWithMinorVersion(int, out PackageIdentity)"/> method with a
-        /// <c>minorVersion</c> of 0, it will return a <c>lastestPublishedPatchVersion</c> of 15 (because
-        /// the latest published version with a major.minor version of 1.0 is v1.0.15). If you pass a
-        /// <c>minorVersion</c> of 1, it will report a patch version of 2 (because the latest (only)
-        /// published version with a major.minor of 1.1 is v1.1.2). And if you specify a <c>minorVersion</c>
-        /// of 2, it will report a patch of 10 because of v1.2.10.
-        /// </para>
-        /// <para>
-        /// If you call this method with a <c>majorVersion</c> of 2, it will return a <see cref="MinorVersions"/>
-        /// reporting a <see cref="MinorVersions.LatestPublishedVersionWithSameMajor"/> of 3 because the latest
-        /// published version with a major version of 2 is v2.3.98. If you ask the <see cref="MinorVersions"/>
-        /// for the latest version with a minor version of 0, it will report a patch of 25 (because of v2.0.25).
-        /// If you ask it about a minor version of 1, it will report that there are no versions with that patch,
-        /// for the major version of 2. If you ask it about minor versions of 2 or 3, it will report patches of
-        /// 12 and 104 respectively.
-        /// </para>
-        /// </remarks>
+        /// <inheritdoc/>
         public bool TryGetLatestVersionsWithMajorVersion(int majorVersion, out INuGetPublishedLibraryMinorVersions latestMatchingMinorVersion)
             => this.latestMinorsByMajor.TryGetValue(majorVersion, out latestMatchingMinorVersion);
 
@@ -93,9 +51,9 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
         /// This is returned by <see cref="TryGetLatestVersionsWithMajorVersion(int, out INuGetPublishedLibraryMinorVersions)"/>.
         /// </para>
         /// </remarks>
-        public class MinorVersions : INuGetPublishedLibraryMinorVersions
+        private class MinorVersions : INuGetPublishedLibraryMinorVersions
         {
-            private readonly Dictionary<int, PackageIdentity> latestPatchesByMinor;
+            private readonly Dictionary<int, NuGetVersion> latestPatchesByMinor;
 
             /// <summary>
             /// Create a <see cref="MinorVersions"/>.
@@ -103,56 +61,28 @@ namespace Endjin.SemVer.DotNetApi.PackageComparison
             /// <param name="publishedVersions">
             /// The minor versions that have been published.
             /// </param>
-            internal MinorVersions(IEnumerable<PackageIdentity> publishedVersions)
+            internal MinorVersions(IEnumerable<NuGetVersion> publishedVersions)
             {
                 this.latestPatchesByMinor = publishedVersions
-                    .GroupBy(v => v.Version.Minor)
+                    .GroupBy(v => v.Minor)
                     .ToDictionary(
                         g => g.Key,
-                        g => g.MaxBy(v => v.Version.Patch).Single());
+                        g => g.MaxBy(v => v.Patch).Single());
 
                 this.LatestPublishedVersionWithSameMajor = this.latestPatchesByMinor[this.latestPatchesByMinor.Keys.Max()];
             }
 
-            /// <summary>
-            /// Gets the identity of the published package with the highest minor version number of
-            /// all versions that share <see cref="MajorVersion"/>.
-            /// </summary>
-            public PackageIdentity LatestPublishedVersionWithSameMajor { get; }
+            /// <inheritdoc/>
+            public NuGetVersion LatestPublishedVersionWithSameMajor { get; }
 
-            /// <summary>
-            /// Gets the latest minor version number with which a package sharing <see cref="MajorVersion"/>
-            /// has been published.
-            /// </summary>
+            /// <inheritdoc/>
             public int LatestPublishedMinorVersionWithSameMajor => this.LatestPublishedVersionWithSameMajor.Version.Minor;
 
-            /// <summary>
-            /// Gets the major version number for which this object describes available minor versions.
-            /// </summary>
-            /// <remarks>
-            /// This will be the same version number specified in the call to
-            /// <see cref="TryGetLatestVersionsWithMajorVersion(int, out INuGetPublishedLibraryMinorVersions)"/> that this
-            /// <see cref="MinorVersions"/> came from.
-            /// </remarks>
+            /// <inheritdoc/>
             public int MajorVersion => this.LatestPublishedVersionWithSameMajor.Version.Major;
 
-            /// <summary>
-            /// Returns the patch number of highest published version with a major version number
-            /// matching <see cref="MajorVersion"/>, and with
-            /// the specified minor version number, if any such version has been published.
-            /// </summary>
-            /// <param name="minorVersion">
-            /// The minor version required.
-            /// </param>
-            /// <param name="lastestPublishedPatchVersion">
-            /// The identity of the package with the highest version number that has been published with this instance's
-            /// <see cref="MajorVersion"/> number and the specified minor version number.
-            /// </param>
-            /// <returns>
-            /// True if at least one version with a matching major.minor version number has been published.
-            /// False if no version with the relevant major.minor version number has been published.
-            /// </returns>
-            public bool TryGetLatestVersionWithMinorVersion(int minorVersion, out PackageIdentity lastestPublishedPatchVersion)
+            /// <inheritdoc/>
+            public bool TryGetLatestVersionWithMinorVersion(int minorVersion, out NuGetVersion lastestPublishedPatchVersion)
                 => this.latestPatchesByMinor.TryGetValue(minorVersion, out lastestPublishedPatchVersion);
         }
     }


### PR DESCRIPTION
Resolves #4 

Also:

 * replaced use of PackageIdentity with NuGetVersion in numerous places where all we actually wanted was a version
 * modified ComparePackages to ignore XML doc files, since their presence/absence has no bearing on SemVer compatibility